### PR TITLE
fix(retention): allow null retention setting to store logs indefinitely

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -24,7 +24,7 @@ class CloudWatch extends AbstractProcessingHandler
     private CloudWatchLogsClient $client;
     private string $group;
     private string $stream;
-    private int $retention;
+    private int | null $retention;
     private bool $initialized = false;
     private int $batchSize;
     /** @var LogRecord[] $buffer */
@@ -63,7 +63,7 @@ class CloudWatch extends AbstractProcessingHandler
         CloudWatchLogsClient $client,
         string $group,
         string $stream,
-        int $retention = 14,
+        int | null $retention = 14,
         int $batchSize = 10000,
         array $tags = [],
         int | string | Level $level = Level::Debug,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  * The [original constructor](https://github.com/maxbanton/cwh/blob/7ad7477e5808763c65691a0db807da5d3c6aa834/src/Handler/CloudWatch.php#L137) in maxbanton's package was not typed so it allowed null values. This then either sets a [retention policy or does not](https://github.com/maxbanton/cwh/blob/7ad7477e5808763c65691a0db807da5d3c6aa834/src/Handler/CloudWatch.php#L374) depending on the value.
  * This change fixes this regression.

* **What is the current behavior?** (You can also link to an open issue here)
  * Does not allow null values, breaking any integrations that previously used null values. This behaviour is stated in the [README](https://github.com/phpnexus/cwh/blob/bb880c252cb8bf9191fb6395ab751a9a84209117/README.md?plain=1#L70) but no longer works:
     * "Days to keep logs, 14 by default. Set to `null` to allow indefinite retention."

* **What is the new behavior (if this is a feature change)?**
  * This corrects the types in the constructor to allow null values. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  * No 

* **Other information**:
