### PR TITLE
Log event size increased to the latest vale

### DIFF
--- a/src/Handler/CloudWatch.php
+++ b/src/Handler/CloudWatch.php
@@ -14,7 +14,7 @@ class CloudWatch extends AbstractProcessingHandler
     /**
      * Event size limit (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html)
      */
-    public const EVENT_SIZE_LIMIT = 262118; // 262144 - reserved 26
+    public const EVENT_SIZE_LIMIT = 1048550; // 1048576 - reserved 26
 
     /**
      * The batch of log events in a single PutLogEvents request cannot span more than 24 hours.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  The April 2025 AWS update raised the upper limit of log event size. In this pull request, we will update our library to update the size that can be sent to the latest value.

* **What is the current behavior?** (You can also link to an open issue here)
  Previously it was 256K including reserved areas.

* **What is the new behavior (if this is a feature change)?**
  I increased it to 1MB.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  There are no breaking changes.

* **Other information**:
  https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-cloudwatch-logs-increases-log-event-size-1-mb/
  ![AWS-Update-Announce](https://github.com/user-attachments/assets/6235add8-087b-4de0-90a4-e3ace54361f1)
  https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html
  ![AWS-Document](https://github.com/user-attachments/assets/9075851d-4e73-4bc8-ac75-1e23ea1bc563)

